### PR TITLE
Fix checking className in styles which broke tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var cssmem = function (styles) {
 
       return classes
         .map(function (className) {
-          if (styles.hasOwnProperty(className)) {
+          if (typeof styles[className] === "string") {
             return styles[className];
           } else {
             if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
When we write tests with identity-obj-proxy for components with cssmem, we have error:
```shell
TypeError: styles.hasOwnProperty is not a function
```
This code fixes that problem